### PR TITLE
Remove generation  of type `uint` kernel parameter

### DIFF
--- a/dtypes.py
+++ b/dtypes.py
@@ -162,7 +162,7 @@ def fill_registry_with_opencl_c_types(reg):
     reg.get_or_register_dtype(["ushort", "unsigned short",
         "unsigned short int", "short unsigned int"], np.uint16)
     reg.get_or_register_dtype(["int", "signed int"], np.int32)
-    reg.get_or_register_dtype(["uint", "unsigned", "unsigned int"], np.uint32)
+    reg.get_or_register_dtype(["unsigned", "unsigned int"], np.uint32)
 
     reg.get_or_register_dtype(
             ["long", "long int", "signed long int",


### PR DESCRIPTION
Kernel generated by the following Loopy program has parameters of type `uint`. 
``` python
import numpy as np
import loopy as lp
from loopy.target.cuda import CudaTarget

knl = lp.make_kernel(
        "{ [i]: 0<=i<n }",
        "out[i] = a[i] + b[i]", target=CudaTarget())

knl = lp.add_and_infer_dtypes(knl, {"a": np.dtype(np.uint32)})
knl = lp.add_and_infer_dtypes(knl, {"b": np.dtype(np.uint32)})
print(lp.generate_code_v2(knl).device_code())
```

Output
``` c
#define bIdx(N) ((int) blockIdx.N)
#define tIdx(N) ((int) threadIdx.N)

extern "C" __global__ void __launch_bounds__(1) loopy_kernel(uint const *__restrict__ a, uint const *__restrict__ b, int const n, uint *__restrict__ out)
{
  for (int i = 0; i <= -1 + n; ++i)
    out[i] = a[i] + b[i];
}
```
But when a kernel with `uint` data type as a parameter is used in a program written using `nvrtc` it generates the following error during compilation.
```
prog.cu(2): error: identifier "uint" is undefined
```
An example program is here.
https://gist.github.com/poorna2152/ca36e60e7a0eac41aaf1969722f6bd2b

- CUDA-version used: 11.7

Therefore the type `uint` generation is removed by removing it from the `fill_registry_with_opencl_c_types` function
 